### PR TITLE
update eval for mmmu

### DIFF
--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -146,6 +146,9 @@ async def eval_mmmu(args) -> None:
             _, response = await process_sample(
                 client, sample, sampling_params, lora_path
             )
+            sample["original_response"] = response
+            if "</think>" in response:
+                response = response.split("</think>")[1]
             answer = (
                 re.search(args.response_answer_regex, response)
                 if response is not None
@@ -168,6 +171,9 @@ async def eval_mmmu(args) -> None:
 
         for coro in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
             sample, response = await coro
+            sample["original_response"] = response
+            if "</think>" in response:
+                response = response.split("</think>")[1]
             answer = (
                 re.search(args.response_answer_regex, response)
                 if response is not None
@@ -187,9 +193,8 @@ async def eval_mmmu(args) -> None:
             print("Profiler stopped")
 
     print(f"Benchmark time: {time.perf_counter() - start}")
-    args.output_path = f"./val_sglang.json"
-    save_json(args.output_path, out_samples)
-    eval_result(model_answer_path=args.output_path, answer_dict=answer_dict)
+    save_json(args.result_filename, out_samples)
+    eval_result(model_answer_path=args.result_filename, answer_dict=answer_dict)
 
 
 def parse_args():

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -147,10 +147,8 @@ async def eval_mmmu(args) -> None:
                 client, sample, sampling_params, lora_path
             )
             sample["original_response"] = response
-            if "</think>" in response:
-                response = response.split("</think>")[1].strip()
             answer = (
-                re.search(args.response_answer_regex, response)
+                re.search(args.response_answer_regex, response).strip()
                 if response is not None
                 else None
             )
@@ -172,10 +170,8 @@ async def eval_mmmu(args) -> None:
         for coro in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
             sample, response = await coro
             sample["original_response"] = response
-            if "</think>" in response:
-                response = response.split("</think>")[1].strip()
             answer = (
-                re.search(args.response_answer_regex, response)
+                re.search(args.response_answer_regex, response).strip()
                 if response is not None
                 else None
             )

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -148,7 +148,7 @@ async def eval_mmmu(args) -> None:
             )
             sample["original_response"] = response
             if "</think>" in response:
-                response = response.split("</think>")[1]
+                response = response.split("</think>")[1].strip()
             answer = (
                 re.search(args.response_answer_regex, response)
                 if response is not None
@@ -173,7 +173,7 @@ async def eval_mmmu(args) -> None:
             sample, response = await coro
             sample["original_response"] = response
             if "</think>" in response:
-                response = response.split("</think>")[1]
+                response = response.split("</think>")[1].strip()
             answer = (
                 re.search(args.response_answer_regex, response)
                 if response is not None

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -124,7 +124,7 @@ async def eval_mmmu(args) -> None:
     answer_dict = {}
     out_samples = {}
     client = openai.AsyncOpenAI(
-        api_key="sk", base_url=f"http://127.0.0.1:{args.port}/v1"
+        api_key="sk", base_url=f"http://127.0.0.1:{args.port}/v1", timeout=20 * 60 * 60,
     )
     start = time.perf_counter()
     base_url = f"http://127.0.0.1:{args.port}"

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -153,7 +153,7 @@ async def eval_mmmu(args) -> None:
                 else None
             )
             process_result(
-                answer.group(1).strip() if answer else response.strip(),
+                answer.group(1).strip() if answer else response,
                 sample,
                 answer_dict,
                 out_samples,
@@ -176,7 +176,7 @@ async def eval_mmmu(args) -> None:
                 else None
             )
             process_result(
-                answer.group(1).strip() if answer else response.strip(),
+                answer.group(1).strip() if answer else response,
                 sample,
                 answer_dict,
                 out_samples,

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -148,12 +148,12 @@ async def eval_mmmu(args) -> None:
             )
             sample["original_response"] = response
             answer = (
-                re.search(args.response_answer_regex, response).strip()
+                re.search(args.response_answer_regex, response)
                 if response is not None
                 else None
             )
             process_result(
-                answer.group(1) if answer else response,
+                answer.group(1).strip() if answer else response.strip(),
                 sample,
                 answer_dict,
                 out_samples,
@@ -171,12 +171,12 @@ async def eval_mmmu(args) -> None:
             sample, response = await coro
             sample["original_response"] = response
             answer = (
-                re.search(args.response_answer_regex, response).strip()
+                re.search(args.response_answer_regex, response)
                 if response is not None
                 else None
             )
             process_result(
-                answer.group(1) if answer else response,
+                answer.group(1).strip() if answer else response.strip(),
                 sample,
                 answer_dict,
                 out_samples,

--- a/benchmark/mmmu/eval_utils.py
+++ b/benchmark/mmmu/eval_utils.py
@@ -18,6 +18,7 @@ from data_utils import (
     construct_prompt,
     load_yaml,
     process_single_sample,
+    save_json,
 )
 from datasets import concatenate_datasets, load_dataset
 from tqdm import tqdm
@@ -28,7 +29,7 @@ class EvalArgs:
     seed: int = 42
     split: str = "validation"
     image_pixels_limit: int = -1
-    result_filename: str = ""
+    result_filename: str = f"./val_sglang.json"
     prompt_format_file: str = "prompt_format.yaml"
     dataset_path: str = "MMMU/MMMU"
     extra_request_body: Optional[str] = None
@@ -445,6 +446,18 @@ def eval_multi_choice(gold_i, pred_i):
     Evaluate a multiple choice instance.
     """
     correct = False
+    # for case like Answer: A, Answer is A, answer is A, answer: A
+    for _exp in ['Answer:', 'Answer is ', 'answer is ', 'answer: ']:
+        if _exp in pred_i:
+            pred_i = pred_i.split(_exp)[1].strip()
+            break
+    # for case like (A), (B), (C), (D) ......
+    if "(" in pred_i and ")" in pred_i:
+        try:
+            pred_i = re.search(r'\(([A-Z])\)', pred_i).group(1)
+        except:
+            print(f"Error to extract answer from: {pred_i}")
+            pass
     # only they are exactly the same, we consider it as correct
     if isinstance(gold_i, list):
         for answer in gold_i:
@@ -535,7 +548,12 @@ def process_result(response, sample, answer_dict, out_samples):
     else:  # open question
         pred_ans = response
 
-    out_samples[sample["id"]] = pred_ans
+    out_samples[sample["id"]] = {
+        "pred_ans": pred_ans,
+        "original_response": sample["original_response"],
+        "ground_truth": sample["answer"],
+        "question_type": sample["question_type"]
+    }
 
     # set ground truth answer
     answer_dict[sample["id"]] = {
@@ -552,6 +570,12 @@ def eval_result(model_answer_path, answer_dict):
     # group by category
     output_dict_w_cat = {}
     for data_id, parsed_pred in output_dict.items():
+        if isinstance(parsed_pred, str):
+            parsed_pred = parsed_pred
+        elif isinstance(parsed_pred, dict):
+            parsed_pred = parsed_pred["pred_ans"]
+        else:
+            raise ValueError(f"Unknown type of parsed_pred: {type(parsed_pred)}")
         category = "_".join(data_id.split("_")[1:-1])
         if category not in output_dict_w_cat:
             output_dict_w_cat.update({category: {}})
@@ -598,9 +622,12 @@ def eval_result(model_answer_path, answer_dict):
 
         judge_dict, metric_dict = evaluate(exampels_to_eval)
         metric_dict.update({"num_example": len(exampels_to_eval)})
+        for key, value in judge_dict.items():
+            output_dict[key]["judge"] = value
 
         evaluation_result[category] = metric_dict
 
+    save_json(model_answer_path, output_dict)
     printable_results = {}
     # pdb.set_trace()
     # add domain Subject
@@ -639,7 +666,7 @@ def eval_result(model_answer_path, answer_dict):
         "acc": overall_acc,
     }
     pprint.pprint(printable_results)
-    out = model_answer_path
+    out = model_answer_path.replace(".json", "_result.json")
     with open(out, "w", encoding="utf-8") as outfile:
         json.dump(printable_results, outfile)
         print(f"eval out saved to {out}")


### PR DESCRIPTION
### run 

``` {shell}
python3 benchmark/mmmu/bench_sglang.py  --concurrency 64 --port 8192 --extra-request-body '{"max_new_tokens": 61440}' --response-answer-regex '\\boxed\{(?:\\text\{)?([^{}]+)\}?}' --reasoning-parser qwen3-thinking
```

### result

<img width="612" height="311" alt="企业微信截图_6105e775-3210-486a-a0c1-6eb462df965a" src="https://github.com/user-attachments/assets/84b28443-c151-4492-abea-61f7ceda2f87" />


Our final accuracy is lower than the paper's, mainly because:

1. The script drops cases with multiple images or high resolutions, which invalidated 20+ questions.
2. Some open-ended answers are in LaTeX format and inconsistent floating-point precision., which are hard to process with simple rules.  (about 10+)



<img width="1227" height="239" alt="image" src="https://github.com/user-attachments/assets/c42e2912-1ec6-4d8e-bd87-86aa0d8cc7b0" />
<img width="901" height="230" alt="image" src="https://github.com/user-attachments/assets/e4b0587d-3e64-4ca7-9f2e-d3771f3af8bb" />
<img width="779" height="137" alt="image" src="https://github.com/user-attachments/assets/13f678d9-5c31-4e98-918f-7d3a14680bd3" />
<img width="1179" height="122" alt="image" src="https://github.com/user-attachments/assets/c09e2f2a-eee8-482c-b778-222df0ffbda1" />
<img width="985" height="469" alt="image" src="https://github.com/user-attachments/assets/99e72e2d-194b-4292-87dd-20088041ad45" />
<img width="1096" height="122" alt="image" src="https://github.com/user-attachments/assets/7e0e9d4f-60df-483e-82b5-7044a9e61bb9" />



